### PR TITLE
Redirect to data stories page instead of root page

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 	
 	gtag('config', 'G-C2ELSYY9VC');
 	</script>
-	<meta http-equiv="Refresh" content="0; url=//cosmicds.cfa.harvard.edu/" />
+	<meta http-equiv="Refresh" content="0; url=//cosmicds.cfa.harvard.edu/data-stories" />
 
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
@@ -22,7 +22,7 @@
 </head>
 
 <body>
-	<p>Please follow <a href="//cosmicds.cfa.harvard.edu/">this link</a>.</p>
+	<p>Please follow <a href="//cosmicds.cfa.harvard.edu/data-stories">this link</a>.</p>
 </body>
 
 </html>


### PR DESCRIPTION
This PR changes the redirect link here to go directly to the data stories page.